### PR TITLE
Fix upstream bug introduced in 742c253 / r10627

### DIFF
--- a/sdcc/src/z80/gen.c
+++ b/sdcc/src/z80/gen.c
@@ -5340,7 +5340,8 @@ genPlusIncr (const iCode * ic)
     (IC_LEFT (ic)->aop->type == AOP_HL || IC_LEFT (ic)->aop->type == AOP_IY))
     {
       fetchPair (PAIR_HL, AOP (IC_LEFT (ic)));
-      emit2 ("inc hl");
+      while (icount--)
+        emit2 ("inc hl");
       regalloc_dry_run_cost++;
       commitPair (AOP (IC_RESULT (ic)), PAIR_HL, ic, FALSE);
       return true;


### PR DESCRIPTION
 Generate correct code for increment by 2 or more in a particular special case that the change in commit 742c253 / upstream revision 10627 detects and generates special code for.

Symptom is that z80 port of FUZIX (0.3 development version) fails to boot, problem occurs at "/bin/sh /etc/rc" step and gives a message like:
```
bootdev: 256
Starting /init
execve /init
init version 0.9.0ac#1
execve /etc/rc
execve /bin/sh
2: out of memory by 130
```
(the execve diagnostics have been added by me so I could figure out what was being executed).

The incorrect code is generated for the function split() in the file Applications/V7/cmd/sh/service.c, the test `if (argp == staktop + BYTESPERWORD)` gets compiled to `if (argp == staktop + 1)` not `if (argp == staktop + 2)`.

I found this bug by observing after some experimentation that the system booted when /bin/sh was taken from 0.2 release, eventually also that latest /bin/sh worked when compiled with release SDCC 3.8.0, then I bisected SDCC and the source files and functions in /bin/sh to find the offending change.

I haven't yet done anything about reporting this bug upstream but will do so when I get to it.